### PR TITLE
fix techlead quadrants

### DIFF
--- a/capra-fagradar/src/tech-leader-radar/index.tsx
+++ b/capra-fagradar/src/tech-leader-radar/index.tsx
@@ -24,25 +24,25 @@ export const TechLeaderRadar = () => {
       name: "Organisasjon",
       orientation: "top-left",
       blipColor: "rgb(71, 161, 173)",
-      blips: [...items.filter((item) => item.quadrant === "Folk")],
+      blips: [...items.filter((item) => item.quadrant === "Organisasjon")],
     },
     {
       name: "Teknologi",
       orientation: "top-right",
       blipColor: "rgb(107, 158, 120)",
-      blips: [...items.filter((item) => item.quadrant === "Organisasjon")],
+      blips: [...items.filter((item) => item.quadrant === "Teknologi")],
     },
     {
       name: "Folk",
       orientation: "bottom-left",
       blipColor: "rgb(204, 133, 10)",
-      blips: [...items.filter((item) => item.quadrant === "Prosess")],
+      blips: [...items.filter((item) => item.quadrant === "Folk")],
     },
     {
       name: "Prosess eller arbeid?",
       orientation: "bottom-right",
       blipColor: "rgb(225, 106, 124)",
-      blips: [...items.filter((item) => item.quadrant === "Teknologi")],
+      blips: [...items.filter((item) => item.quadrant === "Prosess")],
     },
   ] satisfies [Quadrant, Quadrant, Quadrant, Quadrant];
 

--- a/capra-fagradar/src/tech-leader-radar/index.tsx
+++ b/capra-fagradar/src/tech-leader-radar/index.tsx
@@ -21,26 +21,26 @@ for (const modulePath in modules) {
 export const TechLeaderRadar = () => {
   const quadrants = [
     {
-      name: "Folk",
-      orientation: "bottom-left",
+      name: "Organisasjon",
+      orientation: "top-left",
       blipColor: "rgb(71, 161, 173)",
       blips: [...items.filter((item) => item.quadrant === "Folk")],
     },
     {
-      name: "Organisasjon",
-      orientation: "top-left",
+      name: "Teknologi",
+      orientation: "top-right",
       blipColor: "rgb(107, 158, 120)",
       blips: [...items.filter((item) => item.quadrant === "Organisasjon")],
     },
     {
-      name: "Prosess eller arbeid?",
-      orientation: "bottom-right",
+      name: "Folk",
+      orientation: "bottom-left",
       blipColor: "rgb(204, 133, 10)",
       blips: [...items.filter((item) => item.quadrant === "Prosess")],
     },
     {
-      name: "Teknologi",
-      orientation: "top-right",
+      name: "Prosess eller arbeid?",
+      orientation: "bottom-right",
       blipColor: "rgb(225, 106, 124)",
       blips: [...items.filter((item) => item.quadrant === "Teknologi")],
     },


### PR DESCRIPTION
I forrige PR bytta jeg `orientation` i `quadrants`-arrayet i `TechLeaderRadar`-komponenten. Virker som at det har gitt noen spennende bivirkninger. Så jeg satte det tilbake og endra på `name`-feltet i stedet.

<img width="1186" alt="image" src="https://github.com/user-attachments/assets/64929b3e-b0b1-439f-a86b-752232af02f7">
